### PR TITLE
Add Debian 13 build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ cmake --build build --target all --config Release
 ```
 The compiled plugins will be created in `build/SG323_artefacts/Release/`.  
 
+### Debian 13
+Prerequisites:  
+Open a terminal and install basic development tools as well as dependencies for JUCE
+```
+apt install git build-essential cmake libasound2-dev\
+ libcurl4-openssl-dev libfontconfig1-dev libfreetype-dev libwebkit2gtk-4.1-dev juce-tools juce-modules-source
+```
+
+Build it:  
+Open a new terminal and run the following commands  
+```
+git clone --recurse-submodules https://github.com/greyboxaudio/SG-323.git
+cd SG-323/
+cmake -B build
+cmake --build build --target all --config Release
+```
+The compiled plugins will be created in `build/SG323_artefacts/`.  
+
 ## Special thanks
 Dr. Albert Gräf and his team at the Computer Music Research Group http://www.musikinformatik.uni-mainz.de/e_ag.php  
 Joshua Krosenbrink https://www.electroacousticlabs.com/  


### PR DESCRIPTION
I added how to build in Debian 13.

I am not really familiar with C or JUICE, but I read on another forum that just adding the default packages `juce-tools juce-modules-source` may work, and it did. I have compiled and tested the CLAP version and it works great! Please do confirm the PR does not have some problem I am not aware of, I just wanted to help any Debian people out on building your awesome plugin!

Here is a description and version numbers in case it helps:

```sh
Package: juce-tools
Version: 8.0.6+ds-2
Priority: optional
Section: devel
Source: juce
Maintainer: Debian Multimedia Maintainers <debian-multimedia@lists.debian.org>
Installed-Size: 9,910 kB
Depends: libc6 (>= 2.38), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.11.1), libgcc-s1 (>= 3.4), libjpeg62-turbo (>= 1.3.1), libpng16-16t64 (>= 1.6.46), libstdc++6 (>= 14), zlib1g (>= 1:1.1.4)
Recommends: juce-modules-source
Conflicts: introjucer
Breaks: introjucer
Replaces: introjucer
Homepage: https://www.juce.com
Tag: uitoolkit::gtk
Download-Size: 3,147 kB
APT-Manual-Installed: yes
APT-Sources: http://deb.debian.org/debian trixie/main amd64 Packages
Description: JUCE's project management tools
 JUCE (Jules' Utility Class Extensions) is an all-encompassing C++ framework for
 developing cross-platform software.
 The Projucer (formerly Introjucer) is JUCE's project-management tool and secret
 weapon.
 .
 The Projucer's Duties:
  - Central management of cross-platform builds
  - JUCE Module Management
  - New Project Creation
  - User-Interface Design Tool
  - Plug-in Projects
  - Miscellaneous Utilities

Package: juce-modules-source
Version: 8.0.6+ds-2
Priority: optional
Section: devel
Source: juce
Maintainer: Debian Multimedia Maintainers <debian-multimedia@lists.debian.org>
Installed-Size: 12.0 MB
Depends: juce-modules-source-data (= 8.0.6+ds-2), libasound2-dev, libcurl4-gnutls-dev | libcurl-dev, libflac-dev, libfontconfig-dev, libfreetype-dev, libgl-dev, libgtk-3-dev, libjpeg-dev, libpng-dev, libvorbis->
Recommends: fst-dev, lv2-dev
Breaks: juce-tools (<< 7.0.1~), libjuce-dev (<< 5.2.0~)
Replaces: juce-tools (<< 7.0.1~), libjuce-dev (<< 5.2.0~)
Homepage: https://www.juce.com
Tag: uitoolkit::gtk
Download-Size: 2,268 kB
APT-Manual-Installed: yes
APT-Sources: http://deb.debian.org/debian trixie/main amd64 Packages
Description: Jules' Utility Class Extensions (module sources)
 JUCE (Jules' Utility Class Extensions) is an all-encompassing C++ framework for
 developing cross-platform software.
```